### PR TITLE
Plugin update cleanup

### DIFF
--- a/src/handlers/collectionlog/update-collection-log-details.ts
+++ b/src/handlers/collectionlog/update-collection-log-details.ts
@@ -187,7 +187,7 @@ const updateCollectionLogDetails: Handler = async (event: ItemUpdateEvent) => {
             collectionLogEntryId: page?.id,
             name,
             amount,
-            sequence: sequence,
+            sequence,
           });
         }
       });

--- a/src/handlers/collectionlog/update-collection-log.ts
+++ b/src/handlers/collectionlog/update-collection-log.ts
@@ -29,6 +29,7 @@ const updateCollectionLog: APIGatewayProxyHandlerV2 = async (event) => {
       return errorResponse(404, 'Unable to find existing user to update');
     }
 
+    console.log(`STARTING COLLECTION LOG CREATE FOR ${user.username}`);
     collectionLog = await CollectionLog.query().insert({
       isUpdating: true,
       userId: user.id,
@@ -37,7 +38,6 @@ const updateCollectionLog: APIGatewayProxyHandlerV2 = async (event) => {
   }
 
   const { username, isBanned } = collectionLog.user;
-  console.log(username);
 
   if (isBanned) {
     return errorResponse(403, 'User not permitted to upload collection log data');

--- a/src/handlers/user/create-user.ts
+++ b/src/handlers/user/create-user.ts
@@ -30,6 +30,7 @@ const create: APIGatewayProxyHandlerV2 = async (event) => {
 
   const existingUser = await CollectionLogUser.query().findOne({ account_hash: accountHash });
   if (existingUser) {
+    console.log(`EXISTING USER FOR ${body.username} FOUND. STARTING USER UPDATE`);
     await existingUser.$query().update({
       username,
       accountType,

--- a/src/types/CollectionLogData.ts
+++ b/src/types/CollectionLogData.ts
@@ -3,17 +3,19 @@ interface CollectionLogItemData {
   name: string;
   quantity: number;
   obtained: boolean;
+  sequence: number;
 }
 
 interface CollectionLogKillCount {
   amount: number;
   name: string;
+  sequence: number;
 }
 
 interface CollectionLogEntryData {
   [entryName: string]: {
     items: CollectionLogItemData[];
-    killCounts: string[] | CollectionLogKillCount[];
+    killCounts: CollectionLogKillCount[];
   };
 }
 


### PR DESCRIPTION
* Remove code block that handled old kill count upload format
* Add more logging to user/collection log updates
* Use item and kill count sequence data that comes from plugin rather than relying on current iteration of loop
* Remove check if item is unobtained when updating